### PR TITLE
fix: use native Anthropic SDK for API key auth

### DIFF
--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sipeed/picoclaw/pkg/config"
+	anthropicprovider "github.com/sipeed/picoclaw/pkg/providers/anthropic"
 )
 
 // createClaudeAuthProvider creates a Claude provider using OAuth credentials from auth store.
@@ -108,15 +109,12 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 			}
 			return provider, modelID, nil
 		}
-		// Use API key with HTTP API
-		apiBase := cfg.APIBase
-		if apiBase == "" {
-			apiBase = "https://api.anthropic.com/v1"
-		}
+		// Use native Anthropic SDK with API key (calls /v1/messages directly).
+		// This avoids requiring an OpenAI-compatible proxy for Anthropic models.
 		if cfg.APIKey == "" {
 			return nil, "", fmt.Errorf("api_key is required for anthropic protocol (model: %s)", cfg.Model)
 		}
-		return NewHTTPProviderWithMaxTokensField(cfg.APIKey, apiBase, cfg.Proxy, cfg.MaxTokensField), modelID, nil
+		return anthropicprovider.NewProviderWithBaseURL(cfg.APIKey, cfg.APIBase), modelID, nil
 
 	case "antigravity":
 		return NewAntigravityProvider(), modelID, nil


### PR DESCRIPTION
## Summary
- Switch `anthropic/` protocol from OpenAI-compat HTTP provider to native Anthropic SDK
- Enables direct Anthropic API calls without requiring a translation proxy
- The native provider at `pkg/providers/anthropic/` already supports tools, system messages, and all PicoClaw features

## Why
The OpenAI-compat provider calls `/chat/completions` which requires a proxy (Aperture, litellm) between PicoClaw and Anthropic. The native SDK calls `/v1/messages` directly.

## Test plan
- [ ] `go build ./pkg/providers/...` compiles clean
- [ ] PicoClaw connects to Anthropic API directly with API key
- [ ] Tool calls work through native Anthropic SDK