### PR TITLE
feat(greptile): add review configuration and coding standards

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,26 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "style"],
+  "triggerOnUpdates": true,
+  "triggerOnDrafts": false,
+  "ignorePatterns": "build/**\ntarget/**\n*.o\n*.lock\ndist/**\nnode_modules/**",
+  "statusCheck": true,
+  "fixWithAI": true,
+  "shouldUpdateDescription": true,
+  "summarySection": { "included": true, "collapsible": false, "defaultOpen": true },
+  "issuesTableSection": { "included": true, "collapsible": true, "defaultOpen": true },
+  "sequenceDiagramSection": { "included": false, "collapsible": true, "defaultOpen": false },
+  "instructions": "Small utility project. Review for correctness, edge case handling, and clean error messages. Keep scope tight -- flag scope creep in PRs.",
+  "patternRepositories": [],
+  "customContext": {
+    "rules": [
+      "Keep the utility focused -- flag feature creep",
+      "Error messages must be user-facing friendly, not raw panics or stack traces",
+      "CLI argument parsing must handle missing/invalid inputs gracefully",
+      "Add tests for any new functionality"
+    ],
+    "files": [
+      { "path": "CLAUDE.md", "description": "Project conventions and context", "scope": ["**"] }
+    ]
+  }
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,3 @@
+[
+  { "path": "CLAUDE.md", "description": "Project conventions and context", "scope": ["**"] }
+]

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,16 @@
+# tinyclaw: Repo-Specific Review Rules
+
+Inherits all rules from `_org-enforced-rules.md`.
+
+## General
+
+- Keep the utility focused and minimal. Flag scope creep in PRs.
+- Error messages must be user-friendly. No raw panics, stack traces, or cryptic exit codes.
+- CLI argument parsing must validate inputs and provide help text.
+- New functionality must include tests.
+
+## Code Quality
+
+- Prefer standard library over external dependencies for simple operations.
+- Functions should do one thing. Flag functions over ~50 lines for potential splitting.
+- Handle edge cases: empty input, missing files, permission errors.


### PR DESCRIPTION
Adds .greptile/ configuration folder with:
- config.json: review behavior, minimal utility-focused settings
- rules.md: scope discipline, testing, and documentation standards
- files.json: reference to CLAUDE.md for context

Part of Greptile Phase 1 rollout (TIN-58).